### PR TITLE
add redis cache

### DIFF
--- a/mapdutil/mapdutil.go
+++ b/mapdutil/mapdutil.go
@@ -1,0 +1,91 @@
+package mapdutil
+
+import (
+	"github.com/shusson/mapd-api/thrift/e745367/mapd"
+	"git.apache.org/thrift.git/lib/go/thrift"
+	"log"
+	"encoding/json"
+	"time"
+)
+
+// MapDCon wrapper around mapd client
+type MapDCon struct {
+	Client  *mapd.MapDClient
+	Session mapd.TSessionId
+}
+
+// MapDConInfo mapd connection info
+type MapDConInfo struct {
+	Version   string `json:"version"`
+	StartTime int64 `json:"start_time"`
+	ReadOnly  bool `json:"read_only"`
+}
+
+// ConnectToMapD connect to mapd core server
+func ConnectToMapD(user string, pwd string, db string, url string, bufferSize int) (*MapDCon, error) {
+	protocolFactory := thrift.NewTJSONProtocolFactory()
+	transportFactory := thrift.NewTBufferedTransportFactory(bufferSize)
+	socket, err := thrift.NewTHttpPostClient(url)
+	if err != nil {
+		return nil, err
+	}
+	transport, err := transportFactory.GetTransport(socket)
+	if err != nil {
+		return nil, err
+	}
+	if err := transport.Open(); err != nil {
+		return nil, err
+	}
+	client := mapd.NewMapDClientFactory(transport, protocolFactory)
+	sessionID, err := client.Connect(user, pwd, db)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Println("connected to mapd server: ", sessionID)
+	con := &MapDCon{client, sessionID}
+	ConnectionInfo(con)
+	info, err := ConnectionInfo(con)
+	if err != nil {
+		return nil, err
+	}
+	jInfo, err := json.Marshal(info)
+	if err != nil {
+		return nil, err
+	}
+	log.Println(string(jInfo))
+
+	return con, err
+}
+
+// ConnectToMapDWithRetry connect to mapd core server with a retry
+func ConnectToMapDWithRetry(user string, pwd string, db string, url string, bufferSize int, attempts int, sleep time.Duration) (*MapDCon, error) {
+	return retry(attempts, sleep, func() (*MapDCon, error) {
+		log.Println("connecting to mapd server...")
+		return ConnectToMapD(user, pwd, db, url, bufferSize)
+	})
+}
+
+// ConnectionInfo get mapd connection info
+func ConnectionInfo(con *MapDCon) (*MapDConInfo, error) {
+	serverInfo, err := con.Client.GetServerStatus(con.Session)
+	if err != nil {
+		return nil, err
+	}
+	hcr := &MapDConInfo{ReadOnly: serverInfo.ReadOnly, StartTime: serverInfo.StartTime, Version: serverInfo.Version}
+	return hcr, nil
+}
+
+func retry(attempts int, sleep time.Duration, action func() (*MapDCon, error)) (*MapDCon, error) {
+	var err error
+	var con *MapDCon
+	for i := 0; i < attempts; i++ {
+		con, err = action()
+		if err == nil {
+			return con, err
+		}
+		time.Sleep(sleep)
+		log.Println("retrying action after error: ", err)
+	}
+	return con, err
+}

--- a/proxyutil/proxyutil.go
+++ b/proxyutil/proxyutil.go
@@ -1,0 +1,55 @@
+package proxyutil
+
+import (
+	"github.com/garyburd/redigo/redis"
+	"io/ioutil"
+	"github.com/shusson/mapd-api/redisutil"
+	"bytes"
+	"net/http"
+	"net/url"
+	"net/http/httputil"
+)
+
+// Transport we implement our own transport layer so that we can intercept the response in the reverse proxy
+type Transport struct {
+	http.RoundTripper
+	Key string
+	Pool *redis.Pool
+}
+
+// RoundTrip {{inheritDoc}}
+func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	resp, err = t.RoundTripper.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	if t.Key != "" {
+		redisutil.Set(t.Pool, t.Key, b)
+	}
+
+	body := ioutil.NopCloser(bytes.NewReader(b))
+	resp.Body = body
+	resp.ContentLength = int64(len(b))
+	return resp, nil
+}
+
+// ReverseProxy reverse proxies to a server
+func ReverseProxy(w http.ResponseWriter, r *http.Request, body []byte, serverURL *url.URL, t *Transport) {
+	// when writing a request the http lib ignores the request header and reads from the ContentLength field
+	// http://tip.golang.org/pkg/net/http/#Request.Write
+	// https://github.com/golang/go/issues/7682
+	r.ContentLength = int64(len(body))
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	handler := httputil.NewSingleHostReverseProxy(serverURL)
+	handler.Transport = t
+	handler.ServeHTTP(w, r)
+}

--- a/redisutil/redisutil.go
+++ b/redisutil/redisutil.go
@@ -1,0 +1,38 @@
+package redisutil
+
+import (
+	"github.com/garyburd/redigo/redis"
+	"time"
+)
+
+// NewPool construct a new redis pool
+func NewPool(redisURL string) *redis.Pool {
+	return &redis.Pool{
+		MaxIdle:     10,
+		IdleTimeout: 100 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			conn, err := redis.Dial("tcp", redisURL)
+			if err != nil {
+				return nil, err
+			}
+			return conn, err
+		},
+	}
+}
+
+// Get redis get
+func Get(pool *redis.Pool, key string) ([]byte, error) {
+	conn := pool.Get()
+	defer conn.Close()
+
+	return redis.Bytes(conn.Do("GET", key))
+}
+
+// Set redis set
+func Set(pool *redis.Pool, key string, value []byte) error {
+	conn := pool.Get()
+	defer conn.Close()
+
+	_, err := conn.Do("SET", key, value)
+	return err
+}


### PR DESCRIPTION
### what
Add a caching layer for sql queries. If the query exists in the cache, return the result otherwise reverse proxy to mapd server. On the return trip from the mapd server we update the cache

### why
Since our data is static, we can use a cache instead of hitting mapd for every request.