### PR TITLE
lock mapd connection on healthcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 .glide/
 
 .idea
+
+load-test/*.json

--- a/load-test/healthcheck.yml
+++ b/load-test/healthcheck.yml
@@ -1,0 +1,17 @@
+config:
+  target: 'http://localhost:4000'
+  phases:
+    - duration: 3
+      arrivalRate: 100
+  http:
+    tls:
+      rejectUnauthorized: false
+
+scenarios:
+  - flow:
+    - get:
+        url: "/healthcheck"
+        capture:
+          json: $
+          as: "response"
+    - log: "{{ response }}"


### PR DESCRIPTION
### What
Add a mutex lock  around the mapd connection.

### Why
Each http handler runs in it's own go routine and the mapd client is not
thread safe. If 2 healthchecks were to happen close together then there
was a risk of a race condition. 